### PR TITLE
Fix tz-aware datetime handling and add loader tests

### DIFF
--- a/src/data/_tz_utils.py
+++ b/src/data/_tz_utils.py
@@ -1,0 +1,22 @@
+# src/data/_tz_utils.py
+from __future__ import annotations
+
+import pandas as pd
+
+
+def to_utc_index(idx_like) -> pd.DatetimeIndex:
+    """Return a UTC DatetimeIndex from any datetime-like input."""
+    converted = pd.to_datetime(idx_like, errors="coerce", utc=False)
+
+    if isinstance(converted, pd.DatetimeIndex):
+        di = converted
+    elif isinstance(converted, pd.Series):
+        di = pd.DatetimeIndex(converted.array)
+    elif isinstance(converted, pd.Index):
+        di = pd.DatetimeIndex(converted)
+    else:
+        di = pd.DatetimeIndex(pd.Index(converted))
+
+    if di.tz is None:
+        return di.tz_localize("UTC")
+    return di.tz_convert("UTC")

--- a/src/data/alpaca_data.py
+++ b/src/data/alpaca_data.py
@@ -5,6 +5,8 @@ import os
 from datetime import datetime, timezone
 import pandas as pd
 
+from ._tz_utils import to_utc_index
+
 
 def _iso_utc(dt: datetime) -> datetime:
     """Return timezone-aware UTC datetime (alpaca-py accepts dt; no need for iso strings)."""
@@ -85,10 +87,7 @@ def load_ohlcv(symbol: str, start: datetime, end: datetime, timeframe: str = "1D
     keep = [c for c in ("open", "high", "low", "close", "volume") if c in df.columns]
 
     # Ensure UTC tz-aware index and sorted
-    if not isinstance(df.index, pd.DatetimeIndex):
-        df.index = pd.to_datetime(df.index, utc=True, errors="coerce")
-    else:
-        df.index = df.index.tz_localize("UTC") if df.index.tz is None else df.index.tz_convert("UTC")
+    df.index = to_utc_index(df.index)
     df.sort_index(inplace=True)
 
     return df[keep]

--- a/tests/_loader_test_utils.py
+++ b/tests/_loader_test_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from src.data import loader
+
+
+def _make_fake_df(rows: int) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=rows, tz="UTC")
+    data = {
+        "timestamp": idx,
+        "open": [100 + i for i in range(rows)],
+        "high": [101 + i for i in range(rows)],
+        "low": [99 + i for i in range(rows)],
+        "close": [100.5 + i for i in range(rows)],
+        "volume": [1000 + i for i in range(rows)],
+    }
+    return pd.DataFrame(data)
+
+
+def setup_fake_provider(monkeypatch, tmp_path, rows: int = 3) -> Tuple[pd.DataFrame, Path]:
+    """Install fake providers and cache root for loader.get_ohlcv tests."""
+
+    loader.MEM.clear()
+
+    cache_root = tmp_path / "ohlcv_cache"
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    base_df = _make_fake_df(rows)
+
+    def _fake_alpaca(symbol: str, start: datetime, end: datetime, timeframe: str = "1D", **kwargs):
+        # Providers should receive UTC-naive boundaries
+        assert start.tzinfo is None
+        assert end.tzinfo is None
+        return base_df.copy(deep=True)
+
+    def _fake_yahoo(*args, **kwargs):  # pragma: no cover - fallback not used in these tests
+        return pd.DataFrame()
+
+    monkeypatch.setattr(loader, "_cache_root", lambda: cache_root)
+    monkeypatch.setattr(loader.A, "load_ohlcv", _fake_alpaca)
+    monkeypatch.setattr(loader.Y, "load_ohlcv", _fake_yahoo)
+
+    return base_df.copy(deep=True), cache_root

--- a/tests/test_cache_roundtrip.py
+++ b/tests/test_cache_roundtrip.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from src.data import loader
+from tests._loader_test_utils import setup_fake_provider
+
+
+def test_get_ohlcv_writes_and_reads_cache(monkeypatch, tmp_path):
+    _, cache_root = setup_fake_provider(monkeypatch, tmp_path)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+
+    result = loader.get_ohlcv("AAPL", start, end, timeframe="1D", force_provider="alpaca")
+
+    expected_path = cache_root / "alpaca" / "AAPL" / "1D" / "2024-01-01__2024-01-04.parquet"
+    assert expected_path.exists()
+
+    loader.MEM.clear()
+    monkeypatch.setattr(loader.A, "load_ohlcv", lambda *a, **k: pd.DataFrame())
+
+    cached = loader.get_ohlcv("AAPL", start, end, timeframe="1D", force_provider="alpaca")
+
+    assert cached.index.equals(result.index)
+    assert cached.equals(result)

--- a/tests/test_loader_aware.py
+++ b/tests/test_loader_aware.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from src.data import loader
+from tests._loader_test_utils import setup_fake_provider
+
+
+def test_get_ohlcv_accepts_aware_bounds(monkeypatch, tmp_path):
+    base_df, _ = setup_fake_provider(monkeypatch, tmp_path)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+
+    result = loader.get_ohlcv("AAPL", start, end, timeframe="1D", force_provider="alpaca")
+
+    expected_index = pd.DatetimeIndex(base_df["timestamp"])
+    assert result.index.equals(expected_index)
+    assert result.index.tz == expected_index.tz

--- a/tests/test_loader_naive.py
+++ b/tests/test_loader_naive.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pandas as pd
+
+from src.data import loader
+from tests._loader_test_utils import setup_fake_provider
+
+
+def test_get_ohlcv_accepts_naive_bounds(monkeypatch, tmp_path):
+    base_df, _ = setup_fake_provider(monkeypatch, tmp_path)
+
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 3)
+
+    result = loader.get_ohlcv("AAPL", start, end, timeframe="1D", force_provider="alpaca")
+
+    assert list(result.columns) == ["open", "high", "low", "close", "volume"]
+    assert len(result) == len(base_df)
+
+    expected_index = pd.DatetimeIndex(base_df["timestamp"])
+    assert result.index.equals(expected_index)
+    assert result.index.tz == expected_index.tz


### PR DESCRIPTION
## Summary
- add a shared UTC conversion helper for loader and data providers
- harden loader caching against tz-aware inputs and normalize provider data safely
- add focused loader tests covering naive/aware bounds and cache promotion

## Testing
- pytest tests/test_loader_naive.py tests/test_loader_aware.py tests/test_cache_roundtrip.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ae4c2928832a93d42e613adff5c0