### PR TITLE
Adjust evolutionary fitness weighting

### DIFF
--- a/src/optimization/evolutionary.py
+++ b/src/optimization/evolutionary.py
@@ -9,7 +9,8 @@ New in this revision:
     trades_per_symbol_per_year = total_trades / num_symbols / years
     soft penalty outside [trade_rate_min, trade_rate_max]
 - Fitness:
-    base = α*CAGR + β*Calmar + γ*Sharpe
+        base = α*CAGR + β*Calmar + γ*Sharpe + δ*TotalReturn
+        Calmar is clamped to ±calmar_cap before weighting to avoid runaway ratios.
     hold_pen = λ_hold * penalty(avg_holding_days outside [min_hold, max_hold])
     rate_pen = λ_rate * penalty(trade_rate outside [rate_min, rate_max])
     score = base - hold_pen - rate_pen
@@ -115,6 +116,7 @@ def _clamped_fitness(
     alpha_cagr: float,
     beta_calmar: float,
     gamma_sharpe: float,
+    delta_total_return: float,
     # holding window preference
     min_holding_days: float,
     max_holding_days: float,
@@ -126,6 +128,7 @@ def _clamped_fitness(
     # context for rate
     num_symbols: int,
     years: float,
+    calmar_cap: float,
 ) -> float:
     """
     Robust fitness:
@@ -161,7 +164,17 @@ def _clamped_fitness(
     if abs(sharpe) < eps_sharpe:
         sharpe = 0.0
 
-    base = (alpha_cagr * cagr) + (beta_calmar * calmar) + (gamma_sharpe * sharpe)
+    total_return = float(metrics.get("total_return", 0.0) or 0.0)
+
+    if calmar_cap > 0:
+        calmar = max(-calmar_cap, min(calmar, calmar_cap))
+
+    base = (
+        (alpha_cagr * cagr)
+        + (beta_calmar * calmar)
+        + (gamma_sharpe * sharpe)
+        + (delta_total_return * total_return)
+    )
 
     hold_pen = holding_penalty_weight * _holding_penalty(avg_hold, min_holding_days, max_holding_days)
 
@@ -227,8 +240,9 @@ def evolutionary_search(
     eps_sharpe: float = 1e-4,
     # Fitness weights (growth vs risk)
     alpha_cagr: float = 1.0,
-    beta_calmar: float = 1.0,
+    beta_calmar: float = 0.2,
     gamma_sharpe: float = 0.25,
+    delta_total_return: float = 1.0,
     # Holding window preference (avoid day-trading & buy/hold)
     min_holding_days: float = 3.0,
     max_holding_days: float = 30.0,
@@ -237,6 +251,7 @@ def evolutionary_search(
     trade_rate_min: float = 5.0,
     trade_rate_max: float = 50.0,
     trade_rate_penalty_weight: float = 0.5,
+    calmar_cap: float = 3.0,
     # Progress & logging
     progress_cb: Optional[ProgressCb] = None,
     log_file: str = "training.log",
@@ -342,6 +357,7 @@ def evolutionary_search(
                 alpha_cagr=alpha_cagr,
                 beta_calmar=beta_calmar,
                 gamma_sharpe=gamma_sharpe,
+                delta_total_return=delta_total_return,
                 min_holding_days=min_holding_days,
                 max_holding_days=max_holding_days,
                 holding_penalty_weight=holding_penalty_weight,
@@ -350,6 +366,7 @@ def evolutionary_search(
                 trade_rate_penalty_weight=trade_rate_penalty_weight,
                 num_symbols=num_symbols,
                 years=years,
+                calmar_cap=calmar_cap,
             )
 
             trades = int(metrics.get("trades", 0) or 0)
@@ -431,6 +448,13 @@ def evolutionary_search(
             "elite_n": elite_n,
             "breed_n": breed_n,
             "inject_n": inject_n,
+            "fitness_weights": {
+                "alpha_cagr": alpha_cagr,
+                "beta_calmar": beta_calmar,
+                "gamma_sharpe": gamma_sharpe,
+                "delta_total_return": delta_total_return,
+                "calmar_cap": calmar_cap,
+            },
         }
         progress_cb("generation_end", end_payload)
         logger.log("generation_end", end_payload)
@@ -438,7 +462,18 @@ def evolutionary_search(
     elapsed_total = time.time() - t0
     scored.sort(key=lambda x: x[1], reverse=True)
     best = scored[0] if scored else ({}, 0.0)
-    done_payload = {"elapsed_sec": elapsed_total, "best": best[0], "score": best[1]}
+    done_payload = {
+        "elapsed_sec": elapsed_total,
+        "best": best[0],
+        "score": best[1],
+        "fitness_weights": {
+            "alpha_cagr": alpha_cagr,
+            "beta_calmar": beta_calmar,
+            "gamma_sharpe": gamma_sharpe,
+            "delta_total_return": delta_total_return,
+            "calmar_cap": calmar_cap,
+        },
+    }
     progress_cb("done", done_payload)
     logger.log("session_end", done_payload)
     return scored[:5]

--- a/tests/test_evolutionary_fitness.py
+++ b/tests/test_evolutionary_fitness.py
@@ -1,0 +1,70 @@
+"""Unit tests for evolutionary fitness calculation."""
+from __future__ import annotations
+
+from src.optimization.evolutionary import _clamped_fitness
+
+
+_DEF_KWARGS = dict(
+    min_trades=1,
+    min_avg_holding_days_gate=0.0,
+    require_hold_days=False,
+    eps_mdd=1e-4,
+    eps_sharpe=1e-4,
+    alpha_cagr=1.0,
+    beta_calmar=0.2,
+    gamma_sharpe=0.0,
+    delta_total_return=1.0,
+    min_holding_days=0.0,
+    max_holding_days=365.0,
+    holding_penalty_weight=0.0,
+    trade_rate_min=0.0,
+    trade_rate_max=100.0,
+    trade_rate_penalty_weight=0.0,
+    num_symbols=1,
+    years=1.0,
+    calmar_cap=3.0,
+)
+
+
+def test_higher_total_return_increases_fitness() -> None:
+    base_metrics = {
+        "trades": 10,
+        "avg_holding_days": 10.0,
+        "total_return": 0.10,
+        "cagr": 0.10,
+        "calmar": 1.0,
+        "max_drawdown": -0.10,
+        "sharpe": 0.0,
+    }
+    better_return_metrics = {**base_metrics, "total_return": 0.25}
+
+    base_score = _clamped_fitness(base_metrics, **_DEF_KWARGS)
+    better_score = _clamped_fitness(better_return_metrics, **_DEF_KWARGS)
+
+    assert better_score > base_score
+
+
+def test_calmar_cap_prevents_dominance() -> None:
+    balanced_metrics = {
+        "trades": 10,
+        "avg_holding_days": 10.0,
+        "total_return": 0.30,
+        "cagr": 0.10,
+        "calmar": 2.0,
+        "max_drawdown": -0.10,
+        "sharpe": 0.0,
+    }
+    calmar_heavy_metrics = {
+        "trades": 10,
+        "avg_holding_days": 10.0,
+        "total_return": 0.05,
+        "cagr": 0.10,
+        "calmar": 50.0,
+        "max_drawdown": -0.10,
+        "sharpe": 0.0,
+    }
+
+    balanced_score = _clamped_fitness(balanced_metrics, **_DEF_KWARGS)
+    calmar_heavy_score = _clamped_fitness(calmar_heavy_metrics, **_DEF_KWARGS)
+
+    assert balanced_score > calmar_heavy_score


### PR DESCRIPTION
## Summary
- incorporate total return into evolutionary fitness with configurable weighting and Calmar clamping
- expose new fitness defaults and weight reporting through evolutionary_search telemetry
- add unit coverage ensuring total return lifts scores and Calmar ratios remain bounded

## Testing
- pytest tests/test_evolutionary_fitness.py
- pytest tests/test_strategy_adapter_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d832c0455c832abd62c68b96a7868a