### PR TITLE
Hook portfolio liquidity flow into OHLCV cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .streamlit/secrets.toml
 storage/
+.venv/
 __pycache__/
 *.pyc
 .DS_Store

--- a/data/indexes.json
+++ b/data/indexes.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "updated_at": "2024-01-15",
+  "indexes": {
+    "S&P 100 Sample": {
+      "description": "Large-cap bellwethers sampled from the S&P 100 constituents.",
+      "symbols": [
+        "AAPL", "MSFT", "AMZN", "NVDA", "GOOGL", "META", "TSLA", "BRK.B",
+        "JPM", "UNH", "XOM", "V", "MA", "JNJ", "PG", "AVGO", "HD", "MRK",
+        "PEP", "COST", "ABBV", "CSCO", "KO", "ADBE", "CRM", "NFLX", "BAC",
+        "ABT", "ACN", "LIN"
+      ]
+    },
+    "Nasdaq Growth 50": {
+      "description": "High growth technology and communication leaders from the Nasdaq-100.",
+      "symbols": [
+        "AAPL", "MSFT", "AMZN", "NVDA", "META", "GOOGL", "GOOG", "TSLA", "PEP",
+        "AVGO", "COST", "ADBE", "CSCO", "AMD", "QCOM", "TXN", "INTC", "AMAT",
+        "LRCX", "ADI"
+      ]
+    },
+    "Dividend Achievers": {
+      "description": "U.S. dividend growers spanning staples, industrials, and technology.",
+      "symbols": [
+        "PG", "KO", "MCD", "PEP", "JNJ", "WMT", "HD", "LOW", "TGT", "COST",
+        "TXN", "NEE", "CL", "GIS", "HON", "CAT", "LMT", "UPS", "MSFT", "AAPL"
+      ]
+    }
+  }
+}

--- a/src/data/universe.py
+++ b/src/data/universe.py
@@ -1,26 +1,122 @@
 # src/data/universe.py
 from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 DEFAULT_INDEX_PATHS = [
     Path("data/indexes.json"),
     Path("storage/indexes.json"),
 ]
 
+
+def _normalize_symbol(value: object) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    s = s.upper().replace(".", "-")
+    return s
+
+
+def _normalize_member_sequence(seq: Any) -> List[str]:
+    symbols: List[str] = []
+    if isinstance(seq, list):
+        iterable = seq
+    elif isinstance(seq, dict):
+        iterable = list(seq.values())
+    else:
+        return symbols
+
+    seen = set()
+    for item in iterable:
+        symbol: str | None = None
+        if isinstance(item, dict):
+            for key in ("symbol", "ticker", "code", "secid"):
+                if key in item:
+                    symbol = _normalize_symbol(item[key])
+                    break
+            if symbol is None and len(item) == 1:
+                symbol = _normalize_symbol(next(iter(item.values())))
+        else:
+            symbol = _normalize_symbol(item)
+        if symbol and symbol not in seen:
+            seen.add(symbol)
+            symbols.append(symbol)
+    return symbols
+
+
+def _extract_index_map(payload: Any) -> Dict[str, List[str]]:
+    if not isinstance(payload, dict):
+        return {}
+
+    raw_indexes: Dict[str, Any] | None = None
+    if isinstance(payload.get("indexes"), dict):
+        raw_indexes = payload["indexes"]
+    else:
+        # treat top-level mapping if values look list/dict-like
+        candidates = {
+            k: v for k, v in payload.items() if isinstance(v, (list, dict))
+        }
+        if candidates:
+            raw_indexes = candidates
+
+    if not raw_indexes:
+        return {}
+
+    normalized: Dict[str, List[str]] = {}
+    for name, raw in raw_indexes.items():
+        if raw is None:
+            continue
+        symbols: List[str] = []
+        if isinstance(raw, dict):
+            for key in ("symbols", "tickers", "members", "rows", "data"):
+                if key in raw and isinstance(raw[key], (list, dict)):
+                    symbols = _normalize_member_sequence(raw[key])
+                    if symbols:
+                        break
+            if not symbols and all(isinstance(v, (str, dict)) for v in raw.values()):
+                # maybe {"AAPL": {...}, "MSFT": {...}}
+                rows = []
+                for sym_key, val in raw.items():
+                    if isinstance(val, dict):
+                        row = dict(val)
+                        row.setdefault("symbol", sym_key)
+                        rows.append(row)
+                    else:
+                        rows.append({"symbol": val})
+                symbols = _normalize_member_sequence(rows)
+        elif isinstance(raw, list):
+            symbols = _normalize_member_sequence(raw)
+
+        if symbols:
+            normalized[str(name)] = symbols
+    return normalized
+
+
 def load_indexes(path: str | Path | None = None) -> Dict[str, List[str]]:
     if path:
         p = Path(path)
-        return json.loads(p.read_text())
+        if not p.exists():
+            return {}
+        payload = json.loads(p.read_text())
+        return _extract_index_map(payload)
+
     for cand in DEFAULT_INDEX_PATHS:
         if cand.exists():
-            return json.loads(cand.read_text())
-    return {}  # caller handles empty
+            payload = json.loads(cand.read_text())
+            data = _extract_index_map(payload)
+            if data:
+                return data
+    return {}
+
 
 def available_universes() -> List[str]:
     idx = load_indexes()
     return sorted(idx.keys())
+
 
 def get_universe(name: str) -> List[str]:
     idx = load_indexes()

--- a/tests/test_index_catalog.py
+++ b/tests/test_index_catalog.py
@@ -1,0 +1,31 @@
+from src import storage
+from src.data import universe
+
+
+def test_list_index_cache_exposes_sample_universes():
+    indexes = storage.list_index_cache()
+    assert "S&P 100 Sample" in indexes
+    assert "Nasdaq Growth 50" in indexes
+
+
+def test_load_index_members_normalizes_symbols():
+    payload = storage.load_index_members("S&P 100 Sample")
+    assert payload is not None
+    symbols = payload.get("symbols")
+    assert isinstance(symbols, list)
+    assert "BRK-B" in symbols  # normalized from BRK.B in file
+    members = payload.get("members")
+    assert members and all("symbol" in row for row in members)
+    meta = payload.get("meta", {})
+    assert meta.get("source_type") == "aggregate"
+    assert meta.get("source_path", "").endswith("indexes.json")
+
+
+def test_universe_module_reads_index_file():
+    idx_map = universe.load_indexes()
+    assert "Dividend Achievers" in idx_map
+    assert "KO" in idx_map["Dividend Achievers"]
+    available = universe.available_universes()
+    assert available == sorted(idx_map.keys())
+    achievers = universe.get_universe("Dividend Achievers")
+    assert set(achievers) == set(idx_map["Dividend Achievers"])

--- a/tests/test_portfolio_prefetch.py
+++ b/tests/test_portfolio_prefetch.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from src.data import portfolio_prefetch as pf
+from tests._loader_test_utils import setup_fake_provider
+
+
+def test_prefetch_and_cached_window_roundtrip(monkeypatch, tmp_path):
+    base_df, cache_root = setup_fake_provider(monkeypatch, tmp_path, rows=5)
+
+    monkeypatch.setattr(pf, "get_ohlcv_root", lambda: cache_root)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 5, tzinfo=timezone.utc)
+
+    ranges = pf.prefetch_and_ranges(["AAPL"], start, end, timeframe="1D")
+
+    assert "AAPL" in ranges
+    assert ranges["AAPL"]["start"] is not None
+    assert ranges["AAPL"]["end"] is not None
+
+    cached = pf.load_cached_window("AAPL", start, end, timeframe="1D")
+
+    assert not cached.empty
+    assert list(cached.columns) == ["open", "high", "low", "close", "volume"]
+    assert cached.index.tz == timezone.utc
+
+    # ensure cached content matches fake provider after normalization
+    expected = pd.DataFrame(
+        {
+            "open": base_df["open"].tolist(),
+            "high": base_df["high"].tolist(),
+            "low": base_df["low"].tolist(),
+            "close": base_df["close"].tolist(),
+            "volume": base_df["volume"].tolist(),
+        },
+        index=base_df["timestamp"].dt.tz_convert("UTC"),
+    )
+
+    pd.testing.assert_index_equal(cached.index, expected.index, check_names=False)
+    pd.testing.assert_frame_equal(cached, expected, check_names=False)


### PR DESCRIPTION
## Summary
- add utilities to assemble cached OHLCV shards so liquidity can be computed without re-fetching
- update the portfolio page to prefetch universes, read from cache, and surface failures in the UI
- add a regression test that exercises the cache-prefetch roundtrip

## Testing
- pytest tests/test_portfolio_prefetch.py tests/test_index_catalog.py tests/test_cache_roundtrip.py

------
https://chatgpt.com/codex/tasks/task_e_68d9cffb18d0832aacb43e91c0fe2877