### PR TITLE
Add cost attribution reporting to ATR backtest and simulation

### DIFF
--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -14,7 +14,9 @@ to fetch bars. Adjust that import to your real data source.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+import os
+import math
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -35,26 +37,163 @@ except Exception:
 
 """
 BacktestResult = {
-    "equity": pd.Series,               # cumulative equity
-    "daily_returns": pd.Series,        # daily pct returns
+    "equity": pd.Series,               # cumulative equity (post-cost)
+    "daily_returns": pd.Series,        # daily pct returns (post-cost)
     "trades": list[dict],              # see Trade dict below
     "meta": dict,                      # symbol, params, costs, date range, exec_mode, notes
+    "equity_pre_cost": pd.Series,      # optional (gross equity curve)
+    "daily_returns_pre_cost": pd.Series,
+    "trades_df": pd.DataFrame,         # enriched trade log with cost attribution
 }
 
 Trade = {
     "entry_time": pd.Timestamp,
     "exit_time": pd.Timestamp,
-    "entry_price": float,
+    "entry_price": float,              # cost-adjusted fill price (per share)
     "exit_price": float,
     "side": "long"|"short",
-    "return_pct": float,
+    "return_pct": float,               # net of costs
     "holding_days": int,
     "mfe": float, "mae": float,               # return terms (e.g., +0.03, -0.02)
     "day_low": float, "day_high": float,      # entry day range
     "day_low_exit": float, "day_high_exit": float,  # exit day range
-    "decision_price": float, "fill_price": float    # optional execution diag (if you support live)
+    "decision_price": float, "fill_price": float,   # execution diagnostics
+    # --- Optional cost diagnostics ---
+    "gross_entry_price": float,
+    "gross_exit_price": float,
+    "entry_slippage_bps": float,
+    "entry_fee_bps": float,
+    "exit_slippage_bps": float,
+    "exit_fee_bps": float,
+    "signal_time": pd.Timestamp | None,
+    "signal_price": float | None,
+    "exit_signal_time": pd.Timestamp | None,
+    "exit_signal_price": float | None,
+    "quantity": float,
+    "notional_entry": float,
+    "notional_exit": float,
+    "entry_slippage_cost": float,
+    "entry_fee_cost": float,
+    "entry_fixed_cost": float,
+    "exit_slippage_cost": float,
+    "exit_fee_cost": float,
+    "exit_fixed_cost": float,
+    "total_cost": float,
+    "gross_return_pct": float,
+    "gross_pnl": float,
+    "net_pnl": float,
 }
 """
+
+# ---------- Cost model helpers ----------
+
+
+def _coerce_float(value, default: float = 0.0) -> float:
+    try:
+        f = float(value)
+    except Exception:
+        return default
+    if not math.isfinite(f):
+        return default
+    return f
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _env_float(name: str, default: float = 0.0) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return _coerce_float(raw, default=default)
+
+
+@dataclass
+class CostModel:
+    commission_bps: float = 0.0
+    slippage_bps: float = 0.0
+    per_trade_fee: float = 0.0
+    enabled: bool = False
+
+    @classmethod
+    def from_inputs(
+        cls,
+        commission_bps: float = 0.0,
+        slippage_bps: float = 0.0,
+        per_trade_fee: float = 0.0,
+        enabled: bool = False,
+    ) -> "CostModel":
+        commission_bps = max(0.0, _coerce_float(commission_bps, 0.0))
+        slippage_bps = max(0.0, _coerce_float(slippage_bps, 0.0))
+        per_trade_fee = max(0.0, _coerce_float(per_trade_fee, 0.0))
+        active = enabled or (commission_bps > 0.0 or slippage_bps > 0.0 or per_trade_fee > 0.0)
+        return cls(
+            commission_bps=commission_bps,
+            slippage_bps=slippage_bps,
+            per_trade_fee=per_trade_fee,
+            enabled=bool(active),
+        )
+
+    def total_bps(self) -> float:
+        return float(self.commission_bps + self.slippage_bps)
+
+    def as_dict(self) -> dict:
+        return {
+            "commission_bps": float(self.commission_bps),
+            "slippage_bps": float(self.slippage_bps),
+            "per_trade_fee": float(self.per_trade_fee),
+            "enabled": bool(self.enabled),
+        }
+
+    def compute_fill(
+        self,
+        side: str,
+        action: str,
+        price: float,
+        qty: float,
+    ) -> dict:
+        price = _coerce_float(price, 0.0)
+        qty = _coerce_float(qty, 0.0)
+        if not self.enabled or price <= 0.0 or qty <= 0.0:
+            return {
+                "fill_price": price,
+                "slippage_cost": 0.0,
+                "commission_cost": 0.0,
+                "fee_cost": 0.0,
+                "total_cost": 0.0,
+                "slippage_bps": 0.0,
+                "commission_bps": 0.0,
+            }
+
+        total_bps = self.total_bps() / 10_000.0
+        notional = price * qty
+        slippage_cost = notional * (self.slippage_bps / 10_000.0)
+        commission_cost = notional * (self.commission_bps / 10_000.0)
+        fee_cost = self.per_trade_fee
+
+        # Adjust fill directionally based on side/action
+        direction = 1.0
+        if side == "long":
+            direction = 1.0 if action == "entry" else -1.0
+        elif side == "short":
+            direction = -1.0 if action == "entry" else 1.0
+
+        fill_adjust = direction * total_bps
+        fill_price = price * (1.0 + fill_adjust)
+
+        return {
+            "fill_price": float(fill_price),
+            "slippage_cost": float(slippage_cost),
+            "commission_cost": float(commission_cost),
+            "fee_cost": float(fee_cost),
+            "total_cost": float(slippage_cost + commission_cost + fee_cost),
+            "slippage_bps": float(self.slippage_bps),
+            "commission_bps": float(self.commission_bps),
+        }
 
 # ---------- Parameters ----------
 
@@ -67,6 +206,12 @@ class ATRParams:
     tp_multiple: float = 0.0          # optional profit target (in ATRs). 0 disables.
     holding_period_limit: int = 0     # optional max holding days. 0 disables.
     allow_short: bool = False         # optional shorting; default off for simplicity
+    cost_bps: float = 0.0             # legacy single cost slider (mapped into slippage)
+    commission_bps: float = 0.0       # explicit commission component
+    slippage_bps: float = 0.0         # explicit slippage component
+    per_trade_fee: float = 0.0        # flat fee per fill (in account currency)
+    enable_costs: bool = False        # toggle attribution / post-cost accounting
+    delay_bars: int = 0               # optional execution delay (signal -> fill after N bars)
 
 # ---------- Indicators ----------
 
@@ -91,30 +236,110 @@ def backtest_atr_breakout(
     execution: str = "close",   # "close" or "next_open" (if you have opens)
     commission_bps: float = 0.0,
     slippage_bps: float = 0.0,
+    enable_costs: Optional[bool] = None,
+    cost_model: Optional[CostModel] = None,
+    delay_bars: Optional[int] = None,
+    capture_trades_df: Optional[bool] = None,
 ) -> Dict:
     """
     Simple daily ATR breakout, long-only by default.
 
-    Entry:
-      - Long when close > rolling_high(breakout_n) - atr_multiple * ATR
-    Exit:
-      - Exit when close < rolling_low(exit_n)
-      - Or when tp_multiple ATR target hit (if tp_multiple>0)
-      - Or when holding_period_limit reached (if >0)
-
-    This is intentionally simple and readable. All timing diagnostics (MFE/MAE, efficiencies)
-    are computed from available bars within each holding window.
+    Adds optional execution delay (signal on close → execute at future open)
+    and cost attribution via a CostModel that applies slippage/fees at fills.
+    Defaults preserve the original behaviour (costs off, delay=0).
     """
+
+    extra_params: Dict[str, Any] = {}
     if isinstance(params, dict):
-        params = ATRParams(**params)
+        params_dict = dict(params)
+        known = set(ATRParams.__dataclass_fields__.keys())
+        params_core = {k: params_dict[k] for k in list(params_dict.keys()) if k in known}
+        extra_params = {k: params_dict[k] for k in params_dict if k not in known}
+        params = ATRParams(**params_core)
+
+    delay_candidate = _coerce_float(getattr(params, "delay_bars", 0), 0.0)
+    if delay_bars is not None:
+        delay_candidate = _coerce_float(delay_bars, delay_candidate)
+    env_delay = _env_float("ATR_EXECUTION_DELAY_BARS", delay_candidate)
+    delay_bars = int(max(0, _coerce_float(env_delay, delay_candidate)))
+
+    if capture_trades_df is None:
+        capture_trades_df = _env_flag("ATR_CAPTURE_TRADES_DF", True)
+    capture_trades_df = bool(capture_trades_df)
+
+    param_enable_costs = bool(getattr(params, "enable_costs", False))
+    env_enable_costs = _env_flag("ATR_ENABLE_COSTS", False)
+    if enable_costs is None:
+        enable_costs = param_enable_costs or env_enable_costs
+    else:
+        enable_costs = bool(enable_costs)
+
+    commission_cfg = _coerce_float(getattr(params, "commission_bps", commission_bps), 0.0)
+    slippage_cfg = _coerce_float(getattr(params, "slippage_bps", slippage_bps), 0.0)
+    if commission_bps:
+        commission_cfg = _coerce_float(commission_bps, commission_cfg)
+    if slippage_bps:
+        slippage_cfg = _coerce_float(slippage_bps, slippage_cfg)
+    if commission_cfg == 0.0 and slippage_cfg == 0.0:
+        slippage_cfg = max(slippage_cfg, _coerce_float(getattr(params, "cost_bps", 0.0), 0.0))
+    fee_cfg = _coerce_float(getattr(params, "per_trade_fee", 0.0), 0.0)
+
+    commission_cfg = _env_float("ATR_COMMISSION_BPS", commission_cfg)
+    slippage_cfg = _env_float("ATR_SLIPPAGE_BPS", slippage_cfg)
+    fee_cfg = _env_float("ATR_PER_TRADE_FEE", fee_cfg)
+
+    if cost_model is None:
+        cost_model = CostModel.from_inputs(
+            commission_bps=commission_cfg,
+            slippage_bps=slippage_cfg,
+            per_trade_fee=fee_cfg,
+            enabled=enable_costs,
+        )
+    else:
+        cost_model = CostModel.from_inputs(
+            commission_bps=getattr(cost_model, "commission_bps", commission_cfg),
+            slippage_bps=getattr(cost_model, "slippage_bps", slippage_cfg),
+            per_trade_fee=getattr(cost_model, "per_trade_fee", fee_cfg),
+            enabled=enable_costs or getattr(cost_model, "enabled", False),
+        )
+    enable_costs = bool(cost_model.enabled)
 
     df = get_ohlcv(symbol, start, end).copy()
+    base_meta = {
+        "symbol": symbol,
+        "start": pd.Timestamp(start),
+        "end": pd.Timestamp(end),
+        "params": dict(params.__dict__),
+        "extra_params": extra_params,
+        "execution": execution,
+        "delay_bars": delay_bars,
+        "cost_model": cost_model.as_dict(),
+        "notes": "ATR breakout long-only reference engine",
+    }
+
     if df.empty:
+        empty_series = pd.Series(dtype=float)
+        meta = dict(base_meta)
+        meta["costs"] = {
+            "enabled": enable_costs,
+            "summary": {
+                "turnover": 0.0,
+                "weighted_slippage_bps": 0.0,
+                "weighted_fees_bps": 0.0,
+                "pre_cost_cagr": 0.0,
+                "post_cost_cagr": 0.0,
+                "annualized_drag": 0.0,
+                "total_cost": 0.0,
+            },
+        }
         return {
-            "equity": pd.Series(dtype=float),
-            "daily_returns": pd.Series(dtype=float),
+            "equity": empty_series,
+            "daily_returns": empty_series,
             "trades": [],
-            "meta": {"symbol": symbol, "start": start, "end": end, "params": params.__dict__},
+            "equity_pre_cost": empty_series,
+            "daily_returns_pre_cost": empty_series,
+            "trades_df": pd.DataFrame(),
+            "meta": meta,
         }
 
     # Ensure basic columns
@@ -127,135 +352,305 @@ def backtest_atr_breakout(
     roll_high = df["close"].rolling(params.breakout_n).max()
     roll_low = df["close"].rolling(params.exit_n).min()
 
-    # Entry trigger (volatility-adjusted)
     entry_th = roll_high - params.atr_multiple * atr
     long_signal = df["close"] > entry_th
 
-    # State machine
     in_pos = False
-    entry_px = np.nan
-    entry_idx = None
-    trades: List[Dict] = []
+    entry_idx: Optional[int] = None
+    entry_time: Optional[pd.Timestamp] = None
+    entry_decision_price = 0.0
+    entry_signal_time: Optional[pd.Timestamp] = None
+    entry_signal_price: Optional[float] = None
+    entry_breakdown: Dict[str, float] = {"total_cost": 0.0, "slippage_cost": 0.0, "commission_cost": 0.0, "fee_cost": 0.0,
+                                         "slippage_bps": 0.0, "commission_bps": 0.0, "fill_price": 0.0}
+    entry_notional = 0.0
 
-    equity = [starting_equity]
-    # (we’ll mark-to-market as either flat or 1x fully invested; position sizing deliberately omitted here)
+    cash_gross = float(starting_equity)
+    cash_net = float(starting_equity)
     position_qty = 0.0
 
-    # Iterate daily
+    equity_gross = [float(starting_equity)]
+    equity_net = [float(starting_equity)]
+
+    trades: List[Dict] = []
+    trade_rows: List[Dict] = []
+
+    pending_entry: Optional[Dict[str, Any]] = None
+    pending_exit: Optional[Dict[str, Any]] = None
+
+    index_list = list(df.index)
+    n_bars = len(index_list)
+
+    def _safe_price(value: Any, fallback: float) -> float:
+        out = _coerce_float(value, fallback)
+        if out <= 0.0:
+            return fallback
+        return out
+
+    last_close_price: Optional[float] = None
+
     for i, (ts, row) in enumerate(df.iterrows()):
-        price = float(row["close"])
-        day_lo = float(row["low"])
-        day_hi = float(row["high"])
+        price_close = _safe_price(row.get("close"), last_close_price if last_close_price is not None else 0.0)
+        if price_close <= 0.0 and last_close_price is not None:
+            price_close = last_close_price
+        if price_close > 0.0:
+            last_close_price = price_close
+        day_lo = _safe_price(row.get("low"), price_close)
+        day_hi = _safe_price(row.get("high"), price_close)
+        price_open = _safe_price(row.get("open"), price_close)
 
-        # Entry
-        if not in_pos and bool(long_signal.iloc[i]):
-            in_pos = True
-            entry_px = price if execution == "close" else float(row.get("open", price))
-            # apply immediate costs on entry fill
-            fill_mult = 1.0 + (commission_bps + slippage_bps) / 10_000.0
-            entry_fill = entry_px * fill_mult
-            entry_idx = i
-            entry_time = ts
-            # buy 1 unit notionally (equity accounting here is synthetic; sizing logic is left to portfolio layer)
-            position_qty = equity[-1] / entry_fill  # all-in for didactic simplicity
-            decision_px = entry_px  # same as entry for backtest; separate in live
+        exit_trigger: Optional[Dict[str, Any]] = None
+        entry_trigger: Optional[Dict[str, Any]] = None
 
-        # Exit checks
-        exit_reason = None
-        do_exit = False
-        exit_px = None
+        if pending_exit and in_pos:
+            if i - pending_exit.get("signal_idx", i) >= delay_bars:
+                exit_trigger = dict(pending_exit)
+                exit_trigger["from_pending"] = True
+                pending_exit = None
 
-        if in_pos:
-            # Exit on rolling low break
-            if price < roll_low.iloc[i]:
-                do_exit = True
+        if pending_entry and not in_pos:
+            if i - pending_entry.get("signal_idx", i) >= delay_bars:
+                entry_trigger = dict(pending_entry)
+                entry_trigger["from_pending"] = True
+                pending_entry = None
+
+        if in_pos and exit_trigger is None:
+            exit_reason = None
+            exit_px = None
+            if price_close < roll_low.iloc[i]:
                 exit_reason = "roll_low"
-
-            # Exit on TP in ATRs (check intraday range)
-            if not do_exit and params.tp_multiple > 0:
-                target = entry_px * (1.0 + params.tp_multiple * atr.iloc[entry_idx] / entry_px)
-                # if day's high reached target intraday
-                if day_hi >= target:
-                    do_exit = True
-                    exit_reason = "tp_hit_intraday"
-                    # assume exit at target (conservative could be near close)
-                    exit_px = target
-
-            # Exit on holding period
-            if not do_exit and params.holding_period_limit > 0:
-                held = i - entry_idx
-                if held >= params.holding_period_limit:
-                    do_exit = True
+            if exit_reason is None and params.tp_multiple > 0 and entry_idx is not None:
+                atr_at_entry = atr.iloc[entry_idx]
+                if np.isfinite(atr_at_entry) and entry_decision_price > 0:
+                    target = entry_decision_price * (1.0 + params.tp_multiple * atr_at_entry / entry_decision_price)
+                    if day_hi >= target:
+                        exit_reason = "tp_hit_intraday"
+                        exit_px = target
+            if exit_reason is None and params.holding_period_limit > 0 and entry_idx is not None:
+                if (i - entry_idx) >= params.holding_period_limit:
                     exit_reason = "holding_limit"
 
-        # Commit exit
-        if in_pos and do_exit:
-            # Exit price
-            if exit_px is None:
-                exit_px = price if execution == "close" else float(row.get("open", price))
-            # apply costs on exit
-            exit_fill = exit_px * (1.0 - (commission_bps + slippage_bps) / 10_000.0)
+            if exit_reason is not None:
+                trigger = {
+                    "signal_idx": i,
+                    "signal_time": ts,
+                    "signal_price": price_close,
+                    "reason": exit_reason,
+                }
+                if exit_px is not None:
+                    trigger["override_price"] = exit_px
+                if delay_bars > 0 and exit_reason != "tp_hit_intraday":
+                    pending_exit = trigger
+                else:
+                    exit_trigger = trigger
 
-            # Compute MFE/MAE over holding window
-            win_slice = df.iloc[entry_idx:i+1]
-            # returns relative to entry
-            rel = (win_slice["high"] / entry_px) - 1.0
-            mfe = float(rel.max()) if len(rel) else 0.0
-            rel2 = (win_slice["low"] / entry_px) - 1.0
-            mae = float(rel2.min()) if len(rel2) else 0.0
+        if in_pos and exit_trigger is None and i == n_bars - 1:
+            exit_trigger = {
+                "signal_idx": i,
+                "signal_time": ts,
+                "signal_price": price_close,
+                "reason": "final_bar_flatten",
+            }
 
-            trade_ret = (exit_fill - entry_fill) / entry_fill
-            holding_days = (ts - entry_time).days or (i - entry_idx)
+        if not in_pos and entry_trigger is None and bool(long_signal.iloc[i]):
+            trigger = {
+                "signal_idx": i,
+                "signal_time": ts,
+                "signal_price": price_close,
+            }
+            if delay_bars > 0:
+                pending_entry = trigger
+            else:
+                entry_trigger = trigger
 
-            trades.append({
+        if exit_trigger is not None and in_pos and position_qty > 0:
+            base_price = exit_trigger.get("override_price")
+            if base_price is None:
+                if exit_trigger.get("from_pending") and delay_bars > 0:
+                    base_price = price_open
+                else:
+                    base_price = price_close if execution == "close" else price_open
+            exit_price = _safe_price(base_price, price_close)
+
+            qty = position_qty
+            proceeds = exit_price * qty
+            cash_gross += proceeds
+            cash_net += proceeds
+            exit_breakdown = cost_model.compute_fill("long", "exit", exit_price, qty)
+            cash_net -= exit_breakdown["total_cost"]
+            exit_fill = exit_breakdown["fill_price"]
+
+            mfe = mae = 0.0
+            if entry_idx is not None:
+                win_slice = df.iloc[entry_idx:i+1]
+                if not win_slice.empty and entry_decision_price > 0:
+                    rel = (win_slice["high"] / entry_decision_price) - 1.0
+                    rel2 = (win_slice["low"] / entry_decision_price) - 1.0
+                    mfe = float(rel.max()) if len(rel) else 0.0
+                    mae = float(rel2.min()) if len(rel2) else 0.0
+
+            gross_pnl = (exit_price - entry_decision_price) * qty
+            entry_cost_total = entry_breakdown.get("total_cost", 0.0)
+            net_pnl = gross_pnl - entry_cost_total - exit_breakdown["total_cost"]
+            notional_exit = exit_price * qty
+            trade_ret = net_pnl / entry_notional if entry_notional else 0.0
+            holding_days = 0
+            if entry_time is not None:
+                holding_days = (ts - entry_time).days or (i - (entry_idx or i))
+
+            trade_record = {
                 "entry_time": entry_time,
                 "exit_time": ts,
-                "entry_price": float(entry_fill),
+                "entry_price": float(entry_breakdown.get("fill_price", entry_decision_price)),
                 "exit_price": float(exit_fill),
                 "side": "long",
                 "return_pct": float(trade_ret),
                 "holding_days": int(holding_days),
                 "mfe": float(mfe),
                 "mae": float(mae),
-                "day_low": float(df["low"].iloc[entry_idx]),
-                "day_high": float(df["high"].iloc[entry_idx]),
-                "day_low_exit": day_lo,
-                "day_high_exit": day_hi,
-                "decision_price": float(decision_px),
-                "fill_price": float(entry_fill),
-                "exit_reason": exit_reason,
-            })
+                "day_low": float(df["low"].iloc[entry_idx]) if entry_idx is not None else float("nan"),
+                "day_high": float(df["high"].iloc[entry_idx]) if entry_idx is not None else float("nan"),
+                "day_low_exit": float(day_lo),
+                "day_high_exit": float(day_hi),
+                "decision_price": float(entry_decision_price),
+                "fill_price": float(entry_breakdown.get("fill_price", entry_decision_price)),
+                "exit_reason": exit_trigger.get("reason"),
+                "gross_entry_price": float(entry_decision_price),
+                "gross_exit_price": float(exit_price),
+                "entry_slippage_bps": float(entry_breakdown.get("slippage_bps", 0.0)),
+                "entry_fee_bps": float(entry_breakdown.get("commission_bps", 0.0)),
+                "exit_slippage_bps": float(exit_breakdown.get("slippage_bps", 0.0)),
+                "exit_fee_bps": float(exit_breakdown.get("commission_bps", 0.0)),
+                "signal_time": entry_signal_time,
+                "signal_price": float(entry_signal_price) if entry_signal_price is not None else None,
+                "exit_signal_time": exit_trigger.get("signal_time"),
+                "exit_signal_price": float(exit_trigger.get("signal_price")) if exit_trigger.get("signal_price") is not None else None,
+                "quantity": float(qty),
+                "notional_entry": float(entry_notional),
+                "notional_exit": float(notional_exit),
+                "entry_slippage_cost": float(entry_breakdown.get("slippage_cost", 0.0)),
+                "entry_fee_cost": float(entry_breakdown.get("commission_cost", 0.0)),
+                "entry_fixed_cost": float(entry_breakdown.get("fee_cost", 0.0)),
+                "exit_slippage_cost": float(exit_breakdown.get("slippage_cost", 0.0)),
+                "exit_fee_cost": float(exit_breakdown.get("commission_cost", 0.0)),
+                "exit_fixed_cost": float(exit_breakdown.get("fee_cost", 0.0)),
+                "total_cost": float(entry_cost_total + exit_breakdown["total_cost"]),
+                "gross_return_pct": float((exit_price / entry_decision_price) - 1.0) if entry_decision_price > 0 else 0.0,
+                "gross_pnl": float(gross_pnl),
+                "net_pnl": float(net_pnl),
+            }
 
-            # Flat after exit; mark equity to cash
-            equity.append(position_qty * exit_fill)
+            trades.append(trade_record)
+            trade_rows.append(trade_record)
+
             position_qty = 0.0
             in_pos = False
-            entry_px = np.nan
             entry_idx = None
             entry_time = None
+            entry_decision_price = 0.0
+            entry_notional = 0.0
+            entry_signal_time = None
+            entry_signal_price = None
+            entry_breakdown = {"total_cost": 0.0, "slippage_cost": 0.0, "commission_cost": 0.0, "fee_cost": 0.0,
+                               "slippage_bps": 0.0, "commission_bps": 0.0, "fill_price": 0.0}
 
-        else:
-            # Mark-to-market
-            if in_pos and position_qty > 0:
-                equity.append(position_qty * price)
-            else:
-                equity.append(equity[-1])
+        if entry_trigger is not None and not in_pos:
+            base_price = entry_trigger.get("override_price")
+            if base_price is None:
+                if entry_trigger.get("from_pending") and delay_bars > 0:
+                    base_price = price_open
+                else:
+                    base_price = price_close if execution == "close" else price_open
+            entry_price = _safe_price(base_price, price_close)
+            if entry_price > 0 and cash_gross > 0:
+                qty = cash_gross / entry_price
+                position_qty = float(qty)
+                entry_idx = i
+                entry_time = ts
+                entry_decision_price = float(entry_price)
+                entry_notional = entry_decision_price * position_qty
+                cash_gross -= entry_notional
+                cash_net -= entry_notional
+                entry_breakdown = cost_model.compute_fill("long", "entry", entry_decision_price, position_qty)
+                cash_net -= entry_breakdown["total_cost"]
+                entry_signal_time = entry_trigger.get("signal_time")
+                entry_signal_price = entry_trigger.get("signal_price")
+                in_pos = True
 
-    eq = pd.Series(equity[1:], index=df.index)  # drop initial seed
-    daily_returns = eq.pct_change().fillna(0.0)
+        current_gross = cash_gross + position_qty * price_close
+        current_net = cash_net + position_qty * price_close
+        equity_gross.append(float(current_gross))
+        equity_net.append(float(current_net))
+
+    eq_gross = pd.Series(equity_gross[1:], index=df.index)
+    eq_net = pd.Series(equity_net[1:], index=df.index)
+
+    daily_returns_net = eq_net.pct_change().fillna(0.0)
+    daily_returns_gross = eq_gross.pct_change().fillna(0.0)
+
+    trades_df = pd.DataFrame(trade_rows) if capture_trades_df and trade_rows else pd.DataFrame(trade_rows)
+
+    total_notional = float(trades_df["notional_entry"].sum() + trades_df.get("notional_exit", pd.Series(dtype=float)).sum()) if not trades_df.empty else 0.0
+    start_equity = eq_gross.iloc[0] if len(eq_gross) else float(starting_equity)
+    turnover = (total_notional / start_equity) if start_equity else 0.0
+
+    def _weighted(col: str) -> float:
+        if trades_df.empty or total_notional == 0.0 or col not in trades_df.columns:
+            return 0.0
+        if col.endswith("_bps"):
+            weight = trades_df["notional_entry"]
+            if col.startswith("exit_"):
+                weight = trades_df["notional_exit"]
+            weighted = (trades_df[col] * weight).sum()
+            return float(weighted / weight.sum()) if weight.sum() else 0.0
+        return float(trades_df[col].mean())
+
+    total_slip_cost = 0.0
+    total_fee_cost = 0.0
+    if not trades_df.empty:
+        total_slip_cost = float(trades_df["entry_slippage_cost"].sum() + trades_df["exit_slippage_cost"].sum())
+        total_fee_cost = float(trades_df["entry_fee_cost"].sum() + trades_df["exit_fee_cost"].sum() + trades_df["entry_fixed_cost"].sum() + trades_df["exit_fixed_cost"].sum())
+
+    def _cagr(series: pd.Series) -> float:
+        if series is None or len(series) < 2:
+            return 0.0
+        start_val = _coerce_float(series.iloc[0], 0.0)
+        end_val = _coerce_float(series.iloc[-1], 0.0)
+        if not (start_val > 0 and end_val > 0):
+            return 0.0
+        days = (series.index[-1] - series.index[0]).days
+        if days <= 0:
+            return 0.0
+        years = days / 365.25
+        if years <= 0:
+            return 0.0
+        return float((end_val / start_val) ** (1 / years) - 1.0)
+
+    pre_cagr = _cagr(eq_gross)
+    post_cagr = _cagr(eq_net)
+    annualized_drag = pre_cagr - post_cagr
+
+    cost_summary = {
+        "turnover": float(turnover),
+        "weighted_slippage_bps": float(_weighted("entry_slippage_bps") + _weighted("exit_slippage_bps")),
+        "weighted_fees_bps": float(_weighted("entry_fee_bps") + _weighted("exit_fee_bps")),
+        "pre_cost_cagr": float(pre_cagr),
+        "post_cost_cagr": float(post_cagr),
+        "annualized_drag": float(annualized_drag),
+        "total_slippage_cost": float(total_slip_cost),
+        "total_fee_cost": float(total_fee_cost),
+        "total_cost": float(total_slip_cost + total_fee_cost),
+    }
+
+    meta = dict(base_meta)
+    meta["costs"] = {"enabled": enable_costs, "summary": cost_summary}
 
     return {
-        "equity": eq,
-        "daily_returns": daily_returns,
+        "equity": eq_net,
+        "daily_returns": daily_returns_net,
         "trades": trades,
-        "meta": {
-            "symbol": symbol,
-            "start": pd.Timestamp(start),
-            "end": pd.Timestamp(end),
-            "params": params.__dict__,
-            "execution": execution,
-            "commission_bps": commission_bps,
-            "slippage_bps": slippage_bps,
-            "notes": "ATR breakout long-only reference engine",
-        },
+        "equity_pre_cost": eq_gross,
+        "daily_returns_pre_cost": daily_returns_gross,
+        "trades_df": trades_df if capture_trades_df else pd.DataFrame(trade_rows),
+        "meta": meta,
     }

--- a/src/models/atr_breakout.py
+++ b/src/models/atr_breakout.py
@@ -9,7 +9,8 @@ about how ATRParams works internally.
 from __future__ import annotations
 from typing import Any, Dict, Tuple
 
-from src.backtest.engine import ATRParams, backtest_atr_breakout
+from src.backtest.engine import ATRParams, backtest_atr_breakout, CostModel
+from src.backtest.metrics import compute_core_metrics
 
 def _split_execution(p: Dict[str, Any] | Any) -> Tuple[Dict[str, Any] | Any, str]:
     if isinstance(p, dict):
@@ -28,6 +29,22 @@ def run_strategy(
     p, exec_mode = _split_execution(params)
     if isinstance(p, dict):
         p = ATRParams(**p)
+    enable_costs = bool(getattr(p, "enable_costs", False))
+    delay_bars = int(getattr(p, "delay_bars", 0) or 0)
+    commission_override = getattr(p, "commission_bps", None)
+    slippage_override = getattr(p, "slippage_bps", None)
+    per_trade_fee = getattr(p, "per_trade_fee", 0.0)
+    total_cost_bps = getattr(p, "cost_bps", 0.0)
+    if commission_override is None:
+        commission_override = 0.0
+    if slippage_override is None or (slippage_override == 0.0 and commission_override == 0.0 and total_cost_bps):
+        slippage_override = float(total_cost_bps)
+    cost_model = CostModel.from_inputs(
+        commission_bps=commission_override,
+        slippage_bps=slippage_override,
+        per_trade_fee=per_trade_fee,
+        enabled=enable_costs,
+    )
     return backtest_atr_breakout(
         symbol=symbol,
         start=start,
@@ -35,4 +52,79 @@ def run_strategy(
         starting_equity=starting_equity,
         params=p,
         execution=exec_mode,
+        commission_bps=float(commission_override or 0.0),
+        slippage_bps=float(slippage_override or 0.0),
+        enable_costs=enable_costs,
+        delay_bars=delay_bars,
+        cost_model=cost_model,
     )
+
+
+def backtest_single(
+    symbol: str,
+    start,
+    end,
+    breakout_n: int,
+    exit_n: int,
+    atr_n: int,
+    starting_equity: float,
+    atr_multiple: float = 2.0,
+    tp_multiple: float = 0.0,
+    holding_period_limit: int = 0,
+    cost_bps: float = 0.0,
+    commission_bps: float = 0.0,
+    slippage_bps: float = 0.0,
+    per_trade_fee: float = 0.0,
+    enable_costs: bool = False,
+    delay_bars: int = 0,
+    execution: str = "close",
+    **kwargs,
+) -> Dict:
+    params = ATRParams(
+        breakout_n=int(breakout_n),
+        exit_n=int(exit_n),
+        atr_n=int(atr_n),
+        atr_multiple=float(atr_multiple),
+    )
+    params.tp_multiple = float(tp_multiple or 0.0)
+    params.holding_period_limit = int(holding_period_limit or 0)
+    params.cost_bps = float(cost_bps or 0.0)
+    params.commission_bps = float(commission_bps or 0.0)
+    params.slippage_bps = float(slippage_bps or 0.0)
+    params.per_trade_fee = float(per_trade_fee or 0.0)
+    params.enable_costs = bool(enable_costs or params.cost_bps > 0.0 or params.commission_bps > 0.0 or params.slippage_bps > 0.0 or params.per_trade_fee > 0.0)
+    params.delay_bars = int(delay_bars or 0)
+
+    cost_model = CostModel.from_inputs(
+        commission_bps=params.commission_bps,
+        slippage_bps=params.slippage_bps if params.slippage_bps > 0.0 else params.cost_bps,
+        per_trade_fee=params.per_trade_fee,
+        enabled=params.enable_costs,
+    )
+
+    result = backtest_atr_breakout(
+        symbol=symbol,
+        start=start,
+        end=end,
+        starting_equity=starting_equity,
+        params=params,
+        execution=execution,
+        commission_bps=params.commission_bps,
+        slippage_bps=params.slippage_bps if params.slippage_bps > 0.0 else params.cost_bps,
+        enable_costs=params.enable_costs,
+        delay_bars=params.delay_bars,
+        cost_model=cost_model,
+    )
+
+    metrics = compute_core_metrics(result["equity"], result["daily_returns"], result["trades"])
+    eq = result["equity"]
+    final_equity = float(eq.iloc[-1]) if len(eq) else float(starting_equity)
+    start_equity = float(eq.iloc[0]) if len(eq) else float(starting_equity)
+    metrics.update({
+        "final_equity": final_equity,
+        "start_equity": start_equity,
+        "start": start,
+        "end": end,
+    })
+    result["metrics"] = metrics
+    return result


### PR DESCRIPTION
## Summary
- add a configurable CostModel, pre/post cost curves, enriched trade logs, and optional execution delay inside `backtest_atr_breakout`
- extend the ATR breakout strategy wrapper with cost-aware plumbing plus a reusable `backtest_single` helper that returns metrics
- surface aggregated cost attribution metrics on the portfolio simulation page

## Testing
- `pytest` *(fails: existing data loader/index catalog expectations and evolutionary fitness signature issues)*


------
https://chatgpt.com/codex/tasks/task_e_68e07f0f4dc0832a9845edbf72f20187