### PR TITLE
Refine Strategy Adapter page layout

### DIFF
--- a/src/storage.py
+++ b/src/storage.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from datetime import datetime
 
+
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     import pandas as pd
 

--- a/src/utils/tri_panel.py
+++ b/src/utils/tri_panel.py
@@ -5,6 +5,7 @@ import math
 from typing import Optional
 
 import pandas as pd
+import plotly.graph_objects as go
 import streamlit as st
 
 logger = logging.getLogger(__name__)
@@ -257,112 +258,150 @@ def render_tri_panel(
     test_end: "pd.Timestamp | str | None" = None,
     show_test_toggle: bool = True,
 ) -> None:
-    with st.expander(f"\u25b8 {title}"):
-        strategy_norm = _normalize_curve(strategy_curve)
-        if strategy_norm is None or strategy_norm.empty:
-            logger.info("tri_panel no strategy curve available")
-            st.info("Strategy equity curve unavailable; cannot compute TRI comparison.")
-            return
-        spy_norm = _extract_spy_tri(
-            start=strategy_norm.index.min() if not strategy_norm.empty else None,
-            end=strategy_norm.index.max() if not strategy_norm.empty else None,
-        )
-        if spy_norm is None or spy_norm.empty:
-            logger.warning("tri_panel SPY normalization failed")
-            st.warning("SPY TRI data unavailable (loader missing or returned no data).")
-            return
-        combined = pd.concat(
-            [strategy_norm.rename("Strategy"), spy_norm.rename("SPY (TRI)")],
-            axis=1,
-            join="inner",
-        ).dropna()
-        if isinstance(combined.index, pd.DatetimeIndex) and getattr(combined.index, "tz", None) is not None:
+    st.markdown(f"#### {title}")
+    strategy_norm = _normalize_curve(strategy_curve)
+    if strategy_norm is None or strategy_norm.empty:
+        logger.info("tri_panel no strategy curve available")
+        st.info("Strategy equity curve unavailable; cannot compute TRI comparison.")
+        return
+    spy_norm = _extract_spy_tri(
+        start=strategy_norm.index.min() if not strategy_norm.empty else None,
+        end=strategy_norm.index.max() if not strategy_norm.empty else None,
+    )
+    if spy_norm is None or spy_norm.empty:
+        logger.warning("tri_panel SPY normalization failed")
+        st.warning("SPY TRI data unavailable (loader missing or returned no data).")
+        return
+    combined = pd.concat(
+        [strategy_norm.rename("Strategy"), spy_norm.rename("SPY (TRI)")],
+        axis=1,
+        join="inner",
+    ).dropna()
+    if isinstance(combined.index, pd.DatetimeIndex) and getattr(combined.index, "tz", None) is not None:
+        try:
+            combined.index = combined.index.tz_convert(None)
+        except Exception:
             try:
-                combined.index = combined.index.tz_convert(None)
+                combined.index = combined.index.tz_localize(None)
             except Exception:
-                try:
-                    combined.index = combined.index.tz_localize(None)
-                except Exception:
-                    logger.debug("tri_panel failed to drop timezone from combined index", extra={"tz": str(combined.index.tz)})
-                    st.info("Unable to align timezones for TRI comparison.")
-                    return
-        if combined.empty or len(combined) < 10:
-            logger.info(
-                "tri_panel insufficient overlap",
-                extra={"rows": int(len(combined))},
+                logger.debug("tri_panel failed to drop timezone from combined index", extra={"tz": str(combined.index.tz)})
+                st.info("Unable to align timezones for TRI comparison.")
+                return
+    if combined.empty or len(combined) < 10:
+        logger.info(
+            "tri_panel insufficient overlap",
+            extra={"rows": int(len(combined))},
+        )
+        st.info("Insufficient overlapping history between strategy and SPY (requires at least 10 points).")
+        return
+    combined_view = combined
+    test_start_ts = _coerce_timestamp(test_start)
+    test_end_ts = _coerce_timestamp(test_end)
+    test_toggle_available = False
+    restrict_to_test = False
+    if show_test_toggle:
+        if test_start_ts is None or test_end_ts is None:
+            st.info("Test window not provided; displaying full history.")
+        elif test_start_ts > test_end_ts:
+            st.info("Test window start is after end; displaying full history.")
+        else:
+            test_toggle_available = True
+            restrict_to_test = st.checkbox(
+                "Test-only view",
+                value=False,
+                key=f"tri_panel_test_toggle_{title}",
             )
-            st.info("Insufficient overlapping history between strategy and SPY (requires at least 10 points).")
-            return
-        combined_view = combined
-        test_start_ts = _coerce_timestamp(test_start)
-        test_end_ts = _coerce_timestamp(test_end)
-        test_toggle_available = False
-        restrict_to_test = False
-        if show_test_toggle:
-            if test_start_ts is None or test_end_ts is None:
-                st.info("Test window not provided; displaying full history.")
-            elif test_start_ts > test_end_ts:
-                st.info("Test window start is after end; displaying full history.")
-            else:
-                test_toggle_available = True
-                restrict_to_test = st.checkbox(
-                    "Test-only view",
-                    value=False,
-                    key=f"tri_panel_test_toggle_{title}",
-                )
-        if test_toggle_available and restrict_to_test:
-            test_view = combined.loc[(combined.index >= test_start_ts) & (combined.index <= test_end_ts)]
-            if test_view.empty or len(test_view) < 10:
+    if test_toggle_available and restrict_to_test:
+        test_view = combined.loc[(combined.index >= test_start_ts) & (combined.index <= test_end_ts)]
+        if test_view.empty or len(test_view) < 10:
+            logger.info(
+                "tri_panel insufficient test overlap",
+                extra={"rows": int(len(test_view))},
+            )
+            st.info(
+                "Insufficient overlapping history in the test window (requires at least 10 points). Displaying full history.",
+            )
+        else:
+            first_row = test_view.iloc[0]
+            if (first_row <= 0).any():
                 logger.info(
-                    "tri_panel insufficient test overlap",
-                    extra={"rows": int(len(test_view))},
+                    "tri_panel non-positive starting values in test window",
+                    extra={"values": first_row.to_dict()},
                 )
-                st.info(
-                    "Insufficient overlapping history in the test window (requires at least 10 points). Displaying full history.",
-                )
+                st.info("Test window start values must be positive; displaying full history.")
             else:
-                first_row = test_view.iloc[0]
-                if (first_row <= 0).any():
-                    logger.info(
-                        "tri_panel non-positive starting values in test window",
-                        extra={"values": first_row.to_dict()},
-                    )
-                    st.info("Test window start values must be positive; displaying full history.")
-                else:
-                    combined_view = test_view.divide(first_row)
-        strategy_aligned = combined_view["Strategy"]
-        spy_aligned = combined_view["SPY (TRI)"]
-        excess_index = strategy_aligned / spy_aligned
-        if not excess_index.empty:
-            first_excess = excess_index.iloc[0]
-            if pd.notna(first_excess) and first_excess > 0:
-                excess_index = excess_index / float(first_excess)
-        combined_chart = combined_view.copy()
-        combined_chart["Excess Index"] = excess_index
-        tracking_error, information_ratio = _compute_tracking_stats(strategy_aligned, spy_aligned)
-        metrics = pd.DataFrame(
-            {
-                "Metric": [
-                    "Strategy CAGR",
-                    "Strategy MaxDD",
-                    "SPY (TRI) CAGR",
-                    "SPY (TRI) MaxDD",
-                    "Tracking Error (annualized)",
-                    "Information Ratio",
-                ],
-                "Value": [
-                    _format_pct(_compute_cagr(strategy_aligned)),
-                    _format_pct(_compute_max_dd(strategy_aligned)),
-                    _format_pct(_compute_cagr(spy_aligned)),
-                    _format_pct(_compute_max_dd(spy_aligned)),
-                    _format_pct(tracking_error),
-                    _format_ratio(information_ratio),
-                ],
-            }
+                combined_view = test_view.divide(first_row)
+    strategy_aligned = combined_view["Strategy"]
+    spy_aligned = combined_view["SPY (TRI)"]
+    excess_index = strategy_aligned / spy_aligned
+    if not excess_index.empty:
+        first_excess = excess_index.iloc[0]
+        if pd.notna(first_excess) and first_excess > 0:
+            excess_index = excess_index / float(first_excess)
+    combined_chart = combined_view.copy()
+    combined_chart["Excess Index"] = excess_index
+    tracking_error, information_ratio = _compute_tracking_stats(strategy_aligned, spy_aligned)
+    metrics = pd.DataFrame(
+        {
+            "Metric": [
+                "Strategy CAGR",
+                "Strategy MaxDD",
+                "SPY (TRI) CAGR",
+                "SPY (TRI) MaxDD",
+                "Tracking Error (annualized)",
+                "Information Ratio",
+            ],
+            "Value": [
+                _format_pct(_compute_cagr(strategy_aligned)),
+                _format_pct(_compute_max_dd(strategy_aligned)),
+                _format_pct(_compute_cagr(spy_aligned)),
+                _format_pct(_compute_max_dd(spy_aligned)),
+                _format_pct(tracking_error),
+                _format_ratio(information_ratio),
+            ],
+        }
+    )
+
+    fig = go.Figure()
+    for column, color in (
+        ("Strategy", "#1f77b4"),
+        ("SPY (TRI)", "#ff7f0e"),
+        ("Excess Index", "#2ca02c"),
+    ):
+        series = combined_chart[column].dropna()
+        if series.empty:
+            continue
+        fig.add_trace(
+            go.Scatter(
+                x=series.index,
+                y=series.values,
+                mode="lines",
+                name=column,
+                line=dict(width=2, color=color),
+            )
         )
-        st.line_chart(combined_chart)
-        st.dataframe(metrics, use_container_width=True, hide_index=True)
-        st.caption(
-            "Strategy and SPY curves normalized to 1.0 on first overlapping date. "
-            "SPY adjusted close used as TRI proxy when available."
-        )
+
+    fig.update_layout(
+        margin=dict(l=10, r=10, t=10, b=10),
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1.0,
+        ),
+        hovermode="x unified",
+        xaxis_title="Date",
+        yaxis_title="Normalized return",
+    )
+
+    st.plotly_chart(
+        fig,
+        use_container_width=True,
+        config={"displaylogo": False, "modeBarButtonsToRemove": ["lasso2d", "select2d"]},
+    )
+    st.dataframe(metrics, use_container_width=True, hide_index=True)
+    st.caption(
+        "Strategy and SPY curves normalized to 1.0 on first overlapping date. "
+        "SPY adjusted close used as TRI proxy when available."
+    )

--- a/src/utils/tri_panel.py
+++ b/src/utils/tri_panel.py
@@ -384,11 +384,11 @@ def render_tri_panel(
     fig.update_layout(
         margin=dict(l=10, r=10, t=10, b=10),
         legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.02,
-            xanchor="right",
-            x=1.0,
+            orientation="v",
+            yanchor="top",
+            y=1.0,
+            xanchor="left",
+            x=0.0,
         ),
         hovermode="x unified",
         xaxis_title="Date",


### PR DESCRIPTION
## Summary
- reorganize the Strategy Adapter page into a top-to-bottom flow with clearer portfolio coverage metrics
- surface EA controls while tucking optional base parameters and advanced run settings into guided expanders
- streamline results monitoring, status hydration, and the EA parameter save flow for a cleaner presentation
- expose the S&P total return comparison chart inline with full Plotly interactivity instead of hiding it behind an expander

## Testing
- python -m compileall pages/2_Strategy_Adapter.py
- python -m compileall src/utils/tri_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68e0906ff8dc832aa6581e62694d3919